### PR TITLE
Update nord.reg

### DIFF
--- a/src/nord.reg
+++ b/src/nord.reg
@@ -1,7 +1,6 @@
+Windows Registry Editor Version 5.00
 ; Copyright (c) 2016-present Sven Greb <development@svengreb.de>
 ; This source code is licensed under the MIT license found in the license file.
-
-Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Nord]
 "Colour0"="216,222,233"


### PR DESCRIPTION
Comment is put after the line containing version, in order to fix "Not a registry script" error
(because the first line shall be Windows Registry Editor Version X)